### PR TITLE
[FIX] - Typo Host was used instead of DefaultHost

### DIFF
--- a/postmark/postmark.go
+++ b/postmark/postmark.go
@@ -136,7 +136,7 @@ func (c *Client) endpoint(path string) *url.URL {
 	}
 
 	if c.Host == "" {
-		url.Host = HOST
+		url.Host = DefaultHost
 	} else {
 		url.Host = c.Host
 	}


### PR DESCRIPTION
Tried installing the package but it did not work due to Host being used and it not being defined.
