### PR TITLE
Update postmark.go

### DIFF
--- a/postmark/postmark.go
+++ b/postmark/postmark.go
@@ -43,7 +43,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		Tag           string
 		HtmlBody      string `json:",omitempty"`
 		TextBody      string `json:",omitempty"`
-		TemplateId    int
+		TemplateId    int    `json:",omitempty"`
 		TemplateModel map[string]interface{}
 		ReplyTo       string
 		Headers       []map[string]string


### PR DESCRIPTION
Fixes an issue where Postmark returns an error when an undefined TemplateId is used (0 in this case).